### PR TITLE
harvestingkit: first implementation of harvestingkit_cli

### DIFF
--- a/harvestingkit/config.py
+++ b/harvestingkit/config.py
@@ -22,7 +22,39 @@ Basic config for Harvesting Kit.
 """
 
 import os
+from sys import executable
+
 from invenio.config import CFG_ETCDIR
 
 
+def _get_config_environment_variable():
+    try:
+        return os.environ['HARVESTINGKIT_CONFIG_PATH']
+    except:
+        return ''
+
+
+def _get_current_virtualenv():
+    path = executable.split(os.sep)
+    index = path.index('.virtualenvs')
+    return os.sep.join(path[:index+2])
+
+
 CFG_DTDS_PATH = os.path.join(CFG_ETCDIR, 'harvestingdtds')
+
+CFG_POSSIBLE_CONFIG_PATHS = [_get_config_environment_variable(),
+                             (_get_current_virtualenv()
+                              + '/var/harvestingkit/user_config.cfg'),
+                             '/etc/harvestingkit/user_config.cfg']
+CFG_CONFIG_PATH = ''
+
+
+for loc in CFG_POSSIBLE_CONFIG_PATHS:
+    if os.path.exists(loc):
+        CFG_CONFIG_PATH = loc
+        break
+else:
+    raise ValueError('Could not find config.cfg')
+
+CFG_FTP_CONNECTION_ATTEMPTS = 3
+CFG_FTP_TIMEOUT_SLEEP_DURATION = 2

--- a/harvestingkit/configparser.py
+++ b/harvestingkit/configparser.py
@@ -1,0 +1,83 @@
+from ConfigParser import ConfigParser
+
+
+class Bunch:
+    def __init__(self, kwds):
+        tmp = {}
+        for key, value in kwds.iteritems():
+            tmp[key] = Bunch(value) if isinstance(value, dict) else value
+
+        self.__dict__.update(tmp)
+
+    def get_attributes(self):
+        return self.__dict__.keys()
+
+
+def _read_section(config, section, working_dict):
+    working_dict[section] = [item[0].upper() for item in config.items(section)]
+
+
+def _get_sections_to_read_completely(config, working_dict):
+    if working_dict == {}:
+        return config.sections()
+    return [key for key, value in working_dict.iteritems() if value == []]
+
+
+def _prepare_working_dict(config, section_option_dict):
+    working_dict = section_option_dict.copy()  # to not alter the input
+
+    for section in _get_sections_to_read_completely(config, working_dict):
+        _read_section(config, section, working_dict)
+
+    return working_dict
+
+
+def load_config(filename=None, section_option_dict={}):
+    """
+    This function returns a Bunch object from the stated config file.
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    NOTE:
+        The values are not evaluated by default.
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    filename:
+        The desired config file to read.
+        The config file must be written in a syntax readable to the
+        ConfigParser module -> INI syntax
+
+        [sectionA]
+        optionA1 = ...
+        optionA2 = ...
+
+    section_option_dict:
+        A dictionary that contains keys, which are associated to the sections
+        in the config file, and values, which are a list of the desired
+        options.
+        If empty, everything will be loaded.
+        If the lists are empty, everything from the sections will be loaded.
+
+    Example:
+        dict = {'sectionA': ['optionA1', 'optionA2', ...],
+                'sectionB': ['optionB1', 'optionB2', ...]}
+
+        config = get_config('config.cfg', dict)
+        config.sectionA.optionA1
+
+    Other:
+        Bunch can be found in configparser.py
+    """
+
+    config = ConfigParser()
+    config.read(filename)
+
+    working_dict = _prepare_working_dict(config, section_option_dict)
+
+    tmp_dict = {}
+
+    for section, options in working_dict.iteritems():
+        tmp_dict[section] = {}
+        for option in options:
+            tmp_dict[section][option] = config.get(section, option)
+
+    return Bunch(tmp_dict)

--- a/harvestingkit/ftp_utils.py
+++ b/harvestingkit/ftp_utils.py
@@ -278,21 +278,21 @@ class FtpHandler(object):
         ref_1 = []
         ref_2 = []
         i = 1
-        print >> sys.stdout, "\nChecking packages integrity."
+        print("\nChecking packages integrity.")
         for filename in filelist:
             ref_1.append(self.get_filesize(filename))
-        print >> sys.stdout, "\nGoing to sleep for %i sec." % (sleep_time,)
+        print("\nGoing to sleep for %i sec." % (sleep_time,))
         time.sleep(sleep_time)
 
         while sleep_time * i < timeout:
             for filename in filelist:
                 ref_2.append(self.get_filesize(filename))
             if ref_1 == ref_2:
-                print >> sys.stdout, "\nIntegrity OK:)"
+                print(sys.stdout, "\nIntegrity OK:)")
                 logger.info("Packages integrity OK.")
                 break
             else:
-                print >> sys.stdout, "\nWaiting %d time for integrity..." % (i,)
+                print("\nWaiting %d time for integrity..." % (i,))
                 logger.info("\nWaiting %d time for integrity..." % (i,))
                 i += 1
                 ref_1, ref_2 = ref_2, []
@@ -303,7 +303,7 @@ class FtpHandler(object):
                 if val1 != ref_2[count]:
                     not_finished_files.append(filelist[count])
 
-            print >> sys.stdout, "\nOMG, OMG something wrong with integrity."
+            print("\nOMG, OMG something wrong with integrity.")
             logger.error("Integrity check failed for files %s" % (not_finished_files,))
 
     def upload(self, filename, location=''):

--- a/harvestingkit/harvestingkit_cli.py
+++ b/harvestingkit/harvestingkit_cli.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+from argparse import ArgumentParser
+
+from ConfigParser import ConfigParser
+
+from harvestingkit.elsevier_package import ElsevierPackage
+from harvestingkit.oup_package import OxfordPackage
+from harvestingkit.springer_package import SpringerPackage
+
+from harvestingkit.config import CFG_CONFIG_PATH
+
+
+class Bunch:
+    def __init__(self, kwds):
+        self.__dict__.update(kwds)
+
+
+def _convert_to_bool(keyboard_input):
+    keyboard_input = keyboard_input.lower()
+    if (keyboard_input != '' and keyboard_input != 'y'
+       and keyboard_input != 'n'):
+        raise ValueError
+    return True if keyboard_input == '' or keyboard_input == 'y' else False
+
+
+def _query_keyboard_input(checking_function, message):
+    while True:
+        try:
+            return checking_function(raw_input(message))
+        except ValueError:
+            print 'Not a valid option, try again...'
+
+
+def _get_credentials():
+    return {'LOGIN': raw_input('Login: '),
+            'PASSWORD': raw_input('Password: '),
+            'URL': raw_input('URL: ')}
+
+
+def _get_default_ConfigParser():
+    config = ConfigParser()
+    config.read(CFG_CONFIG_PATH)
+    return config
+
+
+def _setup_credentials(config, publisher):
+    for key, value in _get_credentials().iteritems():
+        config.set(publisher, key, value)
+
+
+def _query_user_for_credentials(publishers):
+    config = _get_default_ConfigParser()
+
+    default = ('\033[92m'
+               'Do you want to setup your credentials to harvest from {0}?\n'
+               '[Y]:n?'
+               '\033[0m')
+    for publisher in publishers:
+        if _query_keyboard_input(_convert_to_bool, default.format(publisher)):
+            _setup_credentials(config, publisher)
+
+    with open(CFG_CONFIG_PATH, 'w') as config_file:
+        config.write(config_file)
+
+
+def call_all(settings):
+    if settings.update_credentials:
+        _query_user_for_credentials(['ELSEVIER', 'OXFORD', 'SPRINGER'])
+
+
+def call_elsevier(settings):
+    if settings.update_credentials:
+        _query_user_for_credentials(['ELSEVIER'])
+        return
+
+    elsevier_package = ElsevierPackage(package_name=settings.package_name,
+                                       path=settings.path,
+                                       run_locally=settings.run_locally)
+    elsevier_package.bibupload_it()
+
+
+def call_oxford(settings):
+    if settings.update_credentials:
+        _query_user_for_credentials(['OXFORD'])
+        return
+
+    oxford_package = OxfordPackage(package_name=settings.package_name,
+                                   path=settings.path)
+    oxford_package.bibupload_it()
+    if not settings.dont_empty_ftp:
+        oxford_package.empty_ftp()
+
+
+def call_springer(settings):
+    if settings.update_credentials:
+        _query_user_for_credentials(['SPRINGER'])
+        return
+
+    springer_package = SpringerPackage(package_name=settings.package_name,
+                                       path=settings.path)
+    springer_package.bibupload_it()
+
+
+def call_package(settings):
+    packages = {'all': call_all,
+                'elsevier': call_elsevier,
+                'oxford': call_oxford,
+                'springer': call_springer}
+
+    packages[settings.selected_subparser](settings)
+
+
+def main():
+    argparser = ArgumentParser()
+
+    subparsers = argparser.add_subparsers(dest='selected_subparser')
+
+    all_parser = subparsers.add_parser('all')
+    elsevier_parser = subparsers.add_parser('elsevier')
+    oxford_parser = subparsers.add_parser('oxford')
+    springer_parser = subparsers.add_parser('springer')
+
+    all_parser.add_argument('--update-credentials', action='store_true')
+
+    elsevier_parser.add_argument('--run-locally', action='store_true')
+    elsevier_parser.add_argument('--package-name')
+    elsevier_parser.add_argument('--path')
+    elsevier_parser.add_argument('--CONSYN', action='store_true')
+    elsevier_parser.add_argument('--update-credentials', action='store_true')
+
+    oxford_parser.add_argument('--dont-empty-ftp', action='store_true')
+    oxford_parser.add_argument('--package-name')
+    oxford_parser.add_argument('--path')
+    oxford_parser.add_argument('--update-credentials', action='store_true')
+
+    springer_parser.add_argument('--package-name')
+    springer_parser.add_argument('--path')
+    springer_parser.add_argument('--update-credentials', action='store_true')
+
+    '''
+    Transforms the argparse arguments from Namespace to dict and then to Bunch
+    Therefore it is not necessary to access the arguments using the dict syntax
+    The settings can be called like regular vars on the settings object
+    '''
+
+    settings = Bunch(vars(argparser.parse_args()))
+
+    call_package(settings)
+
+
+if __name__ == '__main__':
+    main()

--- a/harvestingkit/scoap3utils.py
+++ b/harvestingkit/scoap3utils.py
@@ -25,6 +25,7 @@ from __future__ import division
 import sys
 import logging
 from invenio.config import CFG_LOGDIR
+
 from os.path import join
 
 CFG_CROSSREF_DOIS_PER_REQUEST = 10
@@ -124,20 +125,30 @@ def lock_issue():
 
 
 # Creates a logger object
-def create_logger(publisher, filename=join(CFG_LOGDIR, 'scoap3_harvesting.log')):
+def create_logger(publisher,
+                  filename=join(CFG_LOGDIR, 'scoap3_harvesting.log'),
+                  logging_level=logging.DEBUG):
     logger = logging.getLogger(publisher)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter(('%(asctime)s - %(name)s - '
+                                   '%(levelname)-8s - %(message)s'))
+
     fh = logging.FileHandler(filename=filename)
     fh.setFormatter(formatter)
     logger.addHandler(fh)
-    logger.setLevel(logging.DEBUG)
+
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    logger.setLevel(logging_level)
+
     return logger
 
 
 def progress_bar(n):
     num = 0
     while num <= n:
-        yield "\r%d%% [%s%s]" % (num / n * 100, "=" * num, '.' * (n - num))
+        yield "%d [%s%s]" % (num/n*100, "="*num, '.'*(n-num))
         num += 1
 
 
@@ -159,3 +170,60 @@ class FileTypeError(Exception):
 class MissingFFTError(Exception):
     def __init__(self, value=None):
         self.value = value
+
+
+class LoginException(Exception):
+    pass
+
+
+class MissingTagException(Exception):
+    pass
+
+
+def get_remote_file_size(ftp_connector, filename, storage):
+
+        def dir_callback(val):
+            storage.append(val.split()[4])
+        ftp_connector.dir(filename, dir_callback)
+
+
+def check_pkgs_integrity(filelist, logger, ftp_connector,
+                         timeout=120, sleep_time=10):
+    """
+    Checks if files are not being uploaded to server.
+    @timeout - time after which the script will register an error.
+    """
+    ref_1 = []
+    ref_2 = []
+    i = 1
+    print >> sys.stdout, "\nChecking packages integrity."
+    for filename in filelist:
+        # ref_1.append(self.get_remote_file_size(filename))
+        get_remote_file_size(ftp_connector, filename, ref_1)
+    print >> sys.stdout, "\nGoing to sleep for %i sec." % (sleep_time,)
+    time.sleep(sleep_time)
+
+    while sleep_time*i < timeout:
+        for filename in filelist:
+            # ref_2.append(self.get_remote_file_size(filename))
+            get_remote_file_size(ftp_connector, filename, ref_2)
+        if ref_1 == ref_2:
+            print >> sys.stdout, "\nIntegrity OK:)"
+            logger.info("Packages integrity OK.")
+            break
+        else:
+            print >> sys.stdout, "\nWaiting %d time for itegrity..." % (i,)
+            logger.info("\nWaiting %d time for itegrity..." % (i,))
+            i += 1
+            ref_1, ref_2 = ref_2, []
+            time.sleep(sleep_time)
+    else:
+        not_finished_files = []
+        for count, val1 in enumerate(ref_1):
+            if val1 != ref_2[count]:
+                not_finished_files.append(filelist[count])
+
+        print >> sys.stdout, "\nOMG, OMG something wrong with integrity."
+        logger.error("Integrity check faild for files %s"
+                     % (not_finished_files,))
+#### ####

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 BeautifulSoup4
 unidecode
+argcomplete

--- a/setup.py
+++ b/setup.py
@@ -18,19 +18,37 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 import os
+import sys
+import shutil
 
 from setuptools import setup, find_packages
-from invenio.config import CFG_ETCDIR, CFG_PYLIBDIR
 
-dtd_path = os.path.join(CFG_ETCDIR, "harvestingdtd")
+from invenio.config import CFG_ETCDIR, CFG_PYLIBDIR 
+from harvestingkit.config import CFG_POSSIBLE_CONFIG_PATHS, CFG_DTDS_PATH
+
+
 bibtasklet_path = os.path.join(CFG_PYLIBDIR, 'invenio', 'bibsched_tasklets')
 
-req = open('requirements.txt','r')
-requirements = []
-for line in req:
-  if line:
-    requirements.append(line)
-req.close()
+
+def _copy_config_to_desired_location():
+    for loc in CFG_POSSIBLE_CONFIG_PATHS:
+        print loc
+        try:
+            if not os.path.exists(os.path.dirname(loc)):
+                os.makedirs(os.path.dirname(loc))
+                shutil.copyfile('user_config.cfg', loc)
+            break
+        except (OSError, IOError, ValueError) as e:
+            print e 
+    else:
+        print "Couldn't copy the config file."
+        sys.exit(-1)
+
+
+_copy_config_to_desired_location()
+
+with open('requirements.txt', 'r') as req:
+    requirements = req.readlines()
 
 setup(name="HarvestingKit",
       version="0.1",
@@ -38,18 +56,23 @@ setup(name="HarvestingKit",
       data_files=[(bibtasklet_path, ["bibtasklets/bst_elsevier.py",
                                      "bibtasklets/bst_oxford.py",
                                      "bibtasklets/bst_springer.py"]),
-                  (dtd_path, ["dtds/ja5_art501.zip",
-                              "dtds/ja5_art510.zip",
-                              "dtds/ja5_art520.zip",
-                              "dtds/si510.zip",
-                              "dtds/si520.zip",
-                              "dtds/A++V2.4.zip",
-                              "dtds/jats-archiving-dtd-1.0.zip",
-                              "dtds/journal-publishing-dtd-2.3.zip"])],
+                  (CFG_DTDS_PATH, ["dtds/ja5_art501.zip",
+                                   "dtds/ja5_art510.zip",
+                                   "dtds/ja5_art520.zip",
+                                   "dtds/si510.zip",
+                                   "dtds/si520.zip",
+                                   "dtds/A++V2.4.zip",
+                                   "dtds/jats-archiving-dtd-1.0.zip",
+                                   "dtds/journal-publishing-dtd-2.3.zip"])],
       install_requires=requirements,
       author="CERN",
       author_email="admin@inspirehep.net",
-      description="Kit containing scripts and utils for harvesting with Invenio Software.",
+      description=("Kit containing scripts and utils for harvesting ",
+                   "with Invenio Software."),
       license="GPLv2",
       url="https://github.com/inspirehep/harvesting-kit",
-    )
+      entry_points='''
+      [console_scripts]
+      harvestingkit_cli = harvestingkit.harvestingkit_cli:main
+      '''
+      )

--- a/user_config.cfg
+++ b/user_config.cfg
@@ -1,0 +1,15 @@
+[ELSEVIER]
+login = empty
+password = empty
+url = empty
+
+[OXFORD]
+login = empty
+password = empty
+url = empty
+
+[SPRINGER]
+login = empty
+password = empty
+url = empty
+


### PR DESCRIPTION
- harvestingkit_cli.py: Implements a console interface that let's
  the user execute the harvesting scripts from one central place.
  Also provides a way to change the user credentials for those
  scripts.
- configparser.py: Since the user credentials for the harvesting
  moved to user_config.cfg, configparser provides a way to load
  those credentials.
- scoap3utils.py: changed the logger in create_logger to log to
  the console as well as to the file.
- setup.py: Copies the user_config.cfg file to one of the places
  specified in setup.py.
- adds MissingTagException and a brief description to _get_text_from
  _journal_item
- some general cleanup

Signed-off-by: Martin Vesper martin.vesper@cern.ch
