### PR TITLE
Elsevier, JATS: important fixes & clean-up

### DIFF
--- a/harvestingkit/contrast_out_utils.py
+++ b/harvestingkit/contrast_out_utils.py
@@ -29,13 +29,14 @@ def contrast_out_cmp(x, y):
             val = val.split('_')[0]
             val = val.strip("vtex")
         else:
-            for w in ["CERN", "P", "S", "Q", "AB", "J"]:
-                if w is not "CERN" and w in val:
+            val = val[4:]
+            for w in ["P", "S", "Q", "AB", "J", "R"]:
+                if w in val:
                     if w is "P":
                         val_type = 1
                     if w is "Q":
                         val_type = 2
-                    if w is "S":
+                    if w in ["S", "R"]:
                         val_type = 3
                     if w is "AB":
                         val_type = 4

--- a/harvestingkit/jats_utils.py
+++ b/harvestingkit/jats_utils.py
@@ -147,7 +147,7 @@ class JATSParser(object):
         for affiliation in xml.getElementsByTagName("aff"):
             aff_id = affiliation.getAttribute("id").encode('utf-8')
             # removes numbering in from affiliations
-            text = re.sub(r'^(\d+\ ?)', "", xml_to_text(affiliation))
+            text = re.sub(r'^(\d+,\ ?)', "", xml_to_text(affiliation, delimiter=", "))
             affiliations[aff_id] = text
 
         emails = {}

--- a/harvestingkit/scoap3utils.py
+++ b/harvestingkit/scoap3utils.py
@@ -24,7 +24,11 @@ from __future__ import division
 
 import sys
 import logging
+import time
 from invenio.config import CFG_LOGDIR
+from tarfile import TarFile
+from zipfile import ZipFile
+from invenio.errorlib import register_exception
 
 from os.path import join
 
@@ -226,4 +230,18 @@ def check_pkgs_integrity(filelist, logger, ftp_connector,
         print >> sys.stdout, "\nOMG, OMG something wrong with integrity."
         logger.error("Integrity check faild for files %s"
                      % (not_finished_files,))
-#### ####
+
+
+def extract_package(path, package_name, logger):
+    try:
+        if ".tar" in package_name:
+            TarFile.open(package_name).extractall(path)
+        elif ".zip" in package_name:
+            ZipFile(package_name).extractall(path)
+        else:
+            raise FileTypeError("It's not a TAR or ZIP archive.")
+    except Exception as err:
+        register_exception(alert_admin=True,
+                           prefix="Elsevier error extracting package.")
+        logger.error("Error extraction package file: %s %s"
+                     % (path, err))


### PR DESCRIPTION
- Changes JATS affiliation parsing (fix for comma separation).
- Fixes updating Elsevier records with new PDF/A file.
- Fixes sorting packages from Elsevier with name "CERNR".
- Refactores package extraction code.

Co-authored-by: Samuele Kaplun samuele.kaplun@cern.ch
