### PR TITLE
global: refextract indentifier added

### DIFF
--- a/harvestingkit/edpsciences_package.py
+++ b/harvestingkit/edpsciences_package.py
@@ -91,6 +91,7 @@ class EDPSciencesPackage(JatsPackage):
                     data = field.firstChild.data
                     code = field.getAttribute("code")
                     subfields.append((code, data))
+                subfields.append(('9', 'refextract'))
             if ref_type:
                 subfields.append(('d', ref_type))
             if text_ref:
@@ -315,6 +316,8 @@ class EDPSciencesPackage(JatsPackage):
             dom = parseString(ref_xml)
             fields = dom.getElementsByTagName("datafield")[0]
             fields = fields.getElementsByTagName("subfield")
+            if fields:
+                subfields.append(('9', 'refextract'))
             for field in fields:
                 data = field.firstChild.data
                 code = field.getAttribute("code")

--- a/harvestingkit/elsevier_package.py
+++ b/harvestingkit/elsevier_package.py
@@ -264,6 +264,8 @@ class ElsevierPackage(object):
                     dom = xml.dom.minidom.parseString(ref_xml)
                     fields = dom.getElementsByTagName("datafield")[0]
                     fields = fields.getElementsByTagName("subfield")
+                    if fields:
+                        subfields.append(('9', 'refextract'))
                     for field in fields:
                         data = field.firstChild.data
                         code = field.getAttribute("code")


### PR DESCRIPTION
- Adds the subfield 9995C9:refextract for
  references extracted with refextract.

Signed-off-by: Georgios Papoutsakis georgios.papoutsakis@cern.ch
