### PR TITLE
elsevier_package: Gets affiliation from sa:affiliation

### DIFF
--- a/harvestingkit/elsevier_package.py
+++ b/harvestingkit/elsevier_package.py
@@ -473,6 +473,10 @@ class ElsevierPackage(object):
                 ret = xml_to_text(link).strip()
         return ret
 
+    def _affiliation_from_sa_field(self, affiliation):
+        sa_affiliation = affiliation.getElementsByTagName('sa:affiliation')[0]
+        return xml_to_text(sa_affiliation, ', ')
+
     def get_authors(self, xml_doc):
         authors = []
         for author in xml_doc.getElementsByTagName("ce:author"):
@@ -504,8 +508,7 @@ class ElsevierPackage(object):
         affiliations = {}
         for affiliation in xml_doc.getElementsByTagName("ce:affiliation"):
             aff_id = affiliation.getAttribute("id").encode('utf-8')
-            text = re.sub(
-                r'^(\d+\ ?)', "", get_value_in_tag(affiliation, "ce:textfn"))
+            text = self._affiliation_from_sa_field(affiliation)
             affiliations[aff_id] = text
         implicit_affilations = True
         for author in authors:


### PR DESCRIPTION
- Changes the get_authors method to get the affiliation text from the
  sa:affiliation tags (via _affiliation_from_sa_field). According to
  "Tag by Tag The Elsevier DTD 5 Family of XML DTDs" this field is
  required to be present.

Signed-off-by: Martin Vesper martin.vesper@cern.ch
