### PR TITLE
NLM & JATS: fix for extracting authors in collaborations

### DIFF
--- a/harvestingkit/jats_package.py
+++ b/harvestingkit/jats_package.py
@@ -112,6 +112,11 @@ class JatsPackage(object):
     def _get_authors(self):
         authors = []
         for contrib in self.document.getElementsByTagName('contrib'):
+            # Springer puts colaborations in additional "contrib" tag so to
+            # avoid having fake author with all affiliations we skip "contrib"
+            # tag with "contrib" subtags.
+            if contrib.getElementsByTagName('contrib'):
+                continue
             if contrib.getAttribute('contrib-type') == 'author':
                 surname = get_value_in_tag(contrib, 'surname')
                 given_names = get_value_in_tag(contrib, 'given-names')

--- a/harvestingkit/jats_utils.py
+++ b/harvestingkit/jats_utils.py
@@ -116,6 +116,11 @@ class JATSParser(object):
     def get_authors(self, xml):
         authors = []
         for author in xml.getElementsByTagName("contrib"):
+            # Springer puts colaborations in additional "contrib" tag so to
+            # avoid having fake author with all affiliations we skip "contrib"
+            # tag with "contrib" subtags.
+            if author.getElementsByTagName("contrib"):
+                continue
             tmp = {}
             surname = get_value_in_tag(author, "surname")
             if surname:
@@ -123,7 +128,8 @@ class JATSParser(object):
             given_name = get_value_in_tag(author, "given-names")
             if given_name:
                 tmp["given_name"] = given_name.replace('\n', ' ')
-
+            if not surname and not given_name:
+                tmp["name"] = get_value_in_tag(author, "string-name")
             # It's not there
             # orcid = author.getAttribute('orcid').encode('utf-8')
             # if orcid:

--- a/harvestingkit/minidom_utils.py
+++ b/harvestingkit/minidom_utils.py
@@ -42,7 +42,7 @@ def xml_to_text(xml, delimiter=' ', tag_to_remove=None):
             return ''
 
     if xml.nodeType == xml.TEXT_NODE:
-        return xml.wholeText.encode('utf-8').strip()
+        return xml.wholeText.encode('utf-8').strip().strip(',')
     elif 'mml:' in xml.nodeName:
         return xml.toxml().replace('mml:', '').replace('xmlns:mml', 'xmlns').encode('utf-8')
     elif xml.hasChildNodes():


### PR DESCRIPTION
- Fixes extracting authors when "contrib" tag is used to indicate a
  collaboration. To avoid having fake author with all affiliations we
  skip "contrib" tag with "contrib" subtags.
