### PR TITLE
harvestingkit: Adds orcid extraction

### DIFF
--- a/harvestingkit/elsevier_package.py
+++ b/harvestingkit/elsevier_package.py
@@ -534,6 +534,15 @@ class ElsevierPackage(object):
                 self._add_group_affiliation(author, xml_author)
             self._add_global_affiliation(author, xml_author)
 
+    def _add_orcids(self, authors, xml_authors):
+        for author, xml_author in zip(authors, xml_authors):
+            try:
+                orcid = xml_author.getAttribute('orcid')
+                if orcid:
+                    author['orcid'] = 'ORCID:{0}'.format(orcid)
+            except IndexError:
+                continue
+
     def get_authors(self, xml_doc):
             xml_authors = xml_doc.getElementsByTagName("ce:author")
             authors = [self._author_dic_from_xml(author) for author
@@ -543,6 +552,8 @@ class ElsevierPackage(object):
 
             self._add_affiliations(authors, xml_authors,
                                    self._find_affiliations(xml_doc, doi))
+
+            self._add_orcids(authors, xml_authors)
 
             return authors
 

--- a/harvestingkit/jats_utils.py
+++ b/harvestingkit/jats_utils.py
@@ -116,6 +116,16 @@ class JATSParser(object):
             print >> sys.stdout, "Can't find DOI."
         return ret
 
+    def _get_orcid(self, xml_author):
+        try:
+            contrib_id = xml_author.getElementsByTagName('contrib-id')[0]
+            if contrib_id.getAttribute('contrib-id-type') == 'orcid':
+                orcid_raw = xml_to_text(contrib_id)
+                pattern = '\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d[\d|X]'
+                return re.search(pattern, orcid_raw).group()
+        except (IndexError, AttributeError):
+            return None
+
     def get_authors(self, xml):
         authors = []
         for author in xml.getElementsByTagName("contrib"):
@@ -133,10 +143,10 @@ class JATSParser(object):
                 tmp["given_name"] = given_name.replace('\n', ' ')
             if not surname and not given_name:
                 tmp["name"] = get_value_in_tag(author, "string-name")
-            # It's not there
-            # orcid = author.getAttribute('orcid').encode('utf-8')
-            # if orcid:
-            #     tmp["orcid"] = orcid
+            # It's not there yet
+            orcid = self._get_orcid(author)
+            if orcid:
+                tmp["orcid"] = 'ORCID:{0}'.format(orcid)
 
             # cross_refs = author.getElementsByTagName("ce:cross-ref")
             # if cross_refs:

--- a/harvestingkit/tests/data/sample_consyn_output.xml
+++ b/harvestingkit/tests/data/sample_consyn_output.xml
@@ -12,6 +12,7 @@
   </datafield>
   <datafield ind1="" ind2="" tag="100">
     <subfield code="a">Vafa, Cumrun</subfield>
+    <subfield code="j">ORCID:1234-5678-4321-8765</subfield>
     <subfield code="v">Lyman Laboratory of Physics, Harvard University, Cambridge, MA 02138, USA</subfield>
   </datafield>
   <datafield ind1="" ind2="" tag="520">

--- a/harvestingkit/tests/data/sample_consyn_record.xml
+++ b/harvestingkit/tests/data/sample_consyn_record.xml
@@ -53,7 +53,7 @@
 	 	<ja:head>
 	 		<ce:title>Toward classification of conformal theories</ce:title>
 	 		<ce:author-group>
-	 			<ce:author>
+	 			<ce:author orcid="1234-5678-4321-8765">
 	 				<ce:given-name>Cumrun</ce:given-name>
 	 				<ce:surname>Vafa</ce:surname>
 	 			</ce:author>

--- a/harvestingkit/tests/elsevier_package_tests.py
+++ b/harvestingkit/tests/elsevier_package_tests.py
@@ -18,7 +18,7 @@
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 import unittest
 from harvestingkit.elsevier_package import ElsevierPackage
-from xml.dom.minidom import parse
+from xml.dom.minidom import parse, Element
 from os.path import (join,
                      dirname)
 from harvestingkit.tests import (__file__ as folder,
@@ -55,8 +55,23 @@ class ElsevierPackageTests(unittest.TestCase):
         keywords = ['Heavy quarkonia', 'Quark gluon plasma', 'Mott effect', 'X(3872)']
         self.assertEqual(self.els.get_keywords(self.document), keywords)
 
+    def test_add_orcids(self):
+        """
+        According to "Tag by Tag The Elsevier DTD 5 Family of XML DTDs" orcids will be 
+        distributed as an attribute in the ce:author tag.
+        """
+        xml_author = Element('ce:author')
+        xml_author.setAttribute('orcid' , '1234-5678-4321-8765')
+        authors = [{}]
+
+        # _add_orcids will alter the authors list
+        self.els._add_orcids(authors, [xml_author])
+
+        self.assertEqual(authors, [{'orcid': 'ORCID:1234-5678-4321-8765'}])
+
+
     def test_authors(self):
-        authors = [{'affiliation': ['Lyman Laboratory of Physics, Harvard University, Cambridge, MA 02138, USA'], 'surname': 'Vafa', 'given_name': 'Cumrun'}]
+        authors = [{'affiliation': ['Lyman Laboratory of Physics, Harvard University, Cambridge, MA 02138, USA'], 'surname': 'Vafa', 'given_name': 'Cumrun', 'orcid': 'ORCID:1234-5678-4321-8765'}]
         self.assertEqual(self.els.get_authors(self.document), authors)
 
     def test_copyritght(self):

--- a/harvestingkit/tests/jats_utils_tests.py
+++ b/harvestingkit/tests/jats_utils_tests.py
@@ -1,0 +1,32 @@
+import unittest
+
+from xml.dom.minidom import Element, parseString
+
+from harvestingkit.jats_utils import JATSParser
+
+
+class JATSUtilsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.jats_parser = JATSParser()
+    
+    def test_get_orcid(self):
+        """
+        See http://jats.nlm.nih.gov/archiving/tag-library/1.1d1/n-dsw0.html for orcid in contrib tag 
+        """
+
+        xml = parseString(
+              """<contrib>
+                   <contrib-id contrib-id-type="orcid">http://orcid.org/1792-3336-9172-961X</contrib-id>
+                   <name><surname>Fauller</surname>
+                   <given-names>Betty Lou</given-names>
+                   </name>
+                   <degrees>BA, MA</degrees>
+                 </contrib>""")
+
+        self.assertEqual(self.jats_parser._get_orcid(xml), '1792-3336-9172-961X')
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(JATSUtilsTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
- Adds orcid extraction to elsevier_package.py and jats_utils.py

Signed-off-by: Martin Vesper martin.vesper@cern.ch
