### PR TITLE
scripts: strip_bom.py

### DIFF
--- a/harvestingkit/scripts/strip_bom.py
+++ b/harvestingkit/scripts/strip_bom.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# This file is part of Harvesting Kit.
+# Copyright (C) 2014 CERN.
+#
+# Harvesting Kit is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Harvesting Kit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Harvesting Kit; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+# taken from http://stackoverflow.com/a/8898439
+
+import os
+import sys
+import codecs
+
+BUFSIZE = 4096
+BOMLEN = len(codecs.BOM_UTF8)
+
+for path in sys.argv[1:]
+    with open(path, "r+b") as fp:
+        print >> sys.stderr, "Stripping BOM from %s" % path
+        chunk = fp.read(BUFSIZE)
+        if chunk.startswith(codecs.BOM_UTF8):
+            i = 0
+            chunk = chunk[BOMLEN:]
+            while chunk:
+                fp.seek(i)
+                fp.write(chunk)
+                i += len(chunk)
+                fp.seek(BOMLEN, os.SEEK_CUR)
+                chunk = fp.read(BUFSIZE)
+            fp.seek(-BOMLEN, os.SEEK_CUR)
+            fp.truncate()
+


### PR DESCRIPTION
- Introduces new scripts that strips away the BOM UTF8
  character from input files.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
