### PR TITLE
html_utils: always use Python 2.7 version of HTMLParser

### DIFF
--- a/harvestingkit/html_utils.py
+++ b/harvestingkit/html_utils.py
@@ -19,9 +19,23 @@
 
 """HTML utils."""
 
-from HTMLParser import HTMLParser
+# HACK: this is needed to load local HTMLParser from Python 2.7
+# in case Python 2.6 is used.
+import sys
 
 from harvestingkit.utils import escape_for_xml
+
+_tmp_sys_path = sys.path
+_new_sys_path = []
+try:
+    for path in sys.path:
+        if ('dist-packages' in path) or ('site-packages' in path):
+            _new_sys_path.append(path)
+    _new_sys_path.extend(sys.path)
+    sys.path = _new_sys_path
+    from HTMLParser import HTMLParser
+finally:
+    sys.path = _tmp_sys_path
 
 
 class MathMLParser(HTMLParser):

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "requests>=2.2.0",
         "six>=1.7.3",
         "python-dateutil==1.5",
+        "HTMLParser==0.0.2",
     ],
     author="INSPIRE-HEP collaboration",
     author_email="admin@inspirehep.net",


### PR DESCRIPTION
* Adds a new dependency in HTMLParser for better results
  when running Harvesting-Kit in Python 2.6 environments.