### PR TITLE
html_utils: improve '<' escaping

### DIFF
--- a/harvestingkit/html_utils.py
+++ b/harvestingkit/html_utils.py
@@ -90,5 +90,5 @@ class MathMLParser(HTMLParser):
     def html_to_text(cls, html):
         """Return stripped HTML, keeping only MathML."""
         s = cls()
-        s.feed(escape_for_xml(html))
-        return s.get_data()
+        s.feed(html)
+        return escape_for_xml(s.get_data(), tags_to_keep=s.mathml_elements)

--- a/harvestingkit/tests/utils_tests.py
+++ b/harvestingkit/tests/utils_tests.py
@@ -124,6 +124,14 @@ class UtilsTests(unittest.TestCase):
         keep_existing = "for 0.03&lt;x&lt;0.1 and fit to world data"
         self.assertEqual(escape_for_xml(keep_existing), keep_existing)
 
+        from harvestingkit.html_utils import MathMLParser
+
+        self.assertEqual(
+            escape_for_xml("ont essayé à<ll' pliquer",
+                           tags_to_keep=MathMLParser.mathml_elements),
+            "ont essayé à&lt;ll' pliquer"
+        )
+
     def test_fix_dashes(self):
         """Test dashes."""
         self.assertEqual(fix_dashes(u"A–A"), "A-A")

--- a/harvestingkit/utils.py
+++ b/harvestingkit/utils.py
@@ -87,12 +87,18 @@ def record_xml_output(rec, pretty=True):
     return unescape(ret)
 
 
-def escape_for_xml(data):
-    """Transform & and < to XML valid &amp; and &lt."""
+def escape_for_xml(data, tags_to_keep=None):
+    """Transform & and < to XML valid &amp; and &lt.
+
+    Pass a list of tags as string to enable replacement of
+    '<' globally but keep any XML tags in the list.
+    """
     data = re.sub("&(?!(#?)(\d{1,5}|\w{1,8});)", "&amp;", data)
     # Cover these special cases where in mathematical expressions '<'' is used.
     data = re.sub('(<)([\$\%\=\-\_\.\+\d\c\s\b]+)', '&lt;\g<2>', data)
     data = re.sub('(<)([a-z]{1}[^a-z>])', '&lt;\g<2>', data)
+    if tags_to_keep:
+        data = re.sub("(<)(?!([\/]?{0}))".format("|[\/]?".join(tags_to_keep)), '&lt;', data)
     return data
 
 


### PR DESCRIPTION
* Improves the html_to_text escaping to take into account any '<'
  that is not followed by a white-list of MathML commands.

* Adds test case from previously failing sample from production.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>