### PR TITLE
elsevier_package.py: fix bug in calculation of number of pages

### DIFF
--- a/harvestingkit/elsevier_package.py
+++ b/harvestingkit/elsevier_package.py
@@ -937,7 +937,7 @@ class ElsevierPackage(object):
             subfields = []
             doctype = self.get_doctype(xml_doc)
             try:
-                page_count = int(last_page) - int(first_page)
+                page_count = int(last_page) - int(first_page) + 1
                 record_add_field(rec, '300',
                                  subfields=[('a', str(page_count))])
             except ValueError:  # do nothing

--- a/harvestingkit/tests/data/sample_consyn_output.xml
+++ b/harvestingkit/tests/data/sample_consyn_output.xml
@@ -16,7 +16,7 @@
     <subfield code="t">published</subfield>
   </datafield>
   <datafield tag="300" ind1=" " ind2=" ">
-    <subfield code="a">5</subfield>
+    <subfield code="a">6</subfield>
   </datafield>
   <datafield tag="520" ind1=" " ind2=" ">
     <subfield code="a">By studying the representations of the mapping class groups which arise in 2D conformal theories we derive some restrictions on the value of the conformal dimension h i of operators and the central charge c of the Virasoro algebra. As a simple application we show that when there are a finite number of operators in the conformal algebra, the h i and c are all rational.</subfield>


### PR DESCRIPTION
* Replaces lastpage - firstpage by lastpage - firstpage + 1

Signed-off-by: fschwenn <florian.schwennsen@desy.de>