### PR TITLE
pos_package: use bibrecord

### DIFF
--- a/harvestingkit/pos_package.py
+++ b/harvestingkit/pos_package.py
@@ -1,29 +1,34 @@
 # -*- coding: utf-8 -*-
-##
-## This file is part of Harvesting Kit.
-## Copyright (C) 2014 CERN.
-##
-## Harvesting Kit is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 2 of the
-## License, or (at your option) any later version.
-##
-## Harvesting Kit is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Harvesting Kit; if not, write to the Free Software Foundation, Inc.,
-## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#
+# This file is part of Harvesting Kit.
+# Copyright (C) 2014 CERN.
+#
+# Harvesting Kit is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Harvesting Kit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Harvesting Kit; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
 import sys
+
 from datetime import datetime
+
 from harvestingkit.minidom_utils import (get_value_in_tag,
                                          xml_to_text)
 from harvestingkit.utils import (collapse_initials,
-                                 create_record,
-                                 record_add_field,
                                  fix_name_capitalization)
+from harvestingkit.bibrecord import (
+    record_add_field,
+    create_record,
+)
 
 
 class PosPackage(object):

--- a/harvestingkit/tests/data/sample_pos_record.xml
+++ b/harvestingkit/tests/data/sample_pos_record.xml
@@ -15,7 +15,7 @@ http://pos.sissa.it/cgi-bin/oai/oai-script-spires-extended.cgi
         <metadata>
         <pos-ext_dc:pex-dc xmlns:pos-ext_dc="http://pos.sissa.it/pos-ext_dc/pos-ext_dc.xsd" xmlns:pex-dc="http://pos.sissa.it/pos-ext_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pos.sissa.it/pos-ext_dc/ http://pos.sissa.it/pos-ext_dc/pos-ext_dc.xsd">
                 <pex-dc:title>Heavy Flavour Physics Review</pex-dc:title>
-                <pex-dc:creator><pex-dc:name>Aida El-Khadra</pex-dc:name><pex-dc:affiliation>Physics Department, University of Illinois, Urbana, Illinois 61801, USA</pex-dc:affiliation></pex-dc:creator>
+                <pex-dc:creator><pex-dc:name>Aida El-Khadra</pex-dc:name><pex-dc:affiliation>INFN and Università di Firenze</pex-dc:affiliation></pex-dc:creator>
                 <pex-dc:subject>Lattice Field Theory</pex-dc:subject>
                 <pex-dc:description>31st International Symposium on Lattice Field Theory LATTICE 2013; Plenary sessions</pex-dc:description>
                 <pex-dc:publisher>Sissa Medialab</pex-dc:publisher>

--- a/harvestingkit/tests/pos_package_tests.py
+++ b/harvestingkit/tests/pos_package_tests.py
@@ -44,7 +44,7 @@ class POSPackageTests(unittest.TestCase):
     def test_authors(self):
         """Test the field authors."""
         self.assertEqual(self.pos._get_authors(),
-                         [('El-Khadra, Aida', ['Physics Department, University of Illinois, Urbana, Illinois 61801, USA'])])
+                         [('El-Khadra, Aida', ['INFN and Università di Firenze'])])
 
     def test_language(self):
         """Test the field language."""
@@ -74,6 +74,11 @@ class POSPackageTests(unittest.TestCase):
         """Test the field identifier."""
         self.assertEqual(self.pos.get_identifier(), 'oai:pos.sissa.it:LATTICE 2013/001')
 
+    def test_record(self):
+        """Test the field identifier."""
+        record = self.pos.get_record(self.pos.document)
+        self.assertTrue(record["100"])
+        self.assertTrue(record["980"])
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(POSPackageTests)


### PR DESCRIPTION
* Changes the PoS package to use the bibrecord methods instead of
  utils in order to fix an issue with character encoding treatment.

* Adds a test case for the PoS harvesting with special characters.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>