### PR TITLE
aps_package: hedge *.firstChild.data commands

### DIFF
--- a/harvestingkit/aps_package.py
+++ b/harvestingkit/aps_package.py
@@ -55,7 +55,8 @@ class ApsPackage(JatsPackage):
             report_no = ''
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'other':
-                    report_no = tag.firstChild.data
+                    if tag.hasChildNodes():
+                        report_no = tag.firstChild.data
             doi = ''
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'doi':
@@ -66,18 +67,14 @@ class ApsPackage(JatsPackage):
             for author_group in person_groups:
                 if author_group.getAttribute('person-group-type') == 'author':
                     for author in author_group.getElementsByTagName('string-name'):
-                        try:
+                        if author.hasChildNodes():
                             authors.append(author.firstChild.data)
-                        except AttributeError:
-                            pass
             editors = []
             for editor_group in person_groups:
                 if editor_group.getAttribute('person-group-type') == 'editor':
                     for editor in editor_group.getElementsByTagName('string-name'):
-                        try:
+                        if editor.hasChildNodes():
                             editors.append(editor.firstChild.data)
-                        except AttributeError:
-                            pass
             journal = get_value_in_tag(innerref, 'source')
             journal, volume = fix_journal_name(journal, self.journal_mappings)
             volume += get_value_in_tag(innerref, 'volume')
@@ -91,7 +88,8 @@ class ApsPackage(JatsPackage):
             arxiv = ''
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'arxiv':
-                    arxiv = tag.firstChild.data
+                    if tag.hasChildNodes():
+                        arxiv = tag.firstChild.data
             arxiv = format_arxiv_id(arxiv)
             publisher = get_value_in_tag(innerref, 'publisher-name')
             publisher_location = get_value_in_tag(innerref, 'publisher-loc')

--- a/harvestingkit/tests/aps_package_tests.py
+++ b/harvestingkit/tests/aps_package_tests.py
@@ -257,11 +257,18 @@ class APSPackageTests(unittest.TestCase):
              '', 'Phys.Rev.', 'D72', '043514', '2005', '21', '', '', '', [], '', '', []),
             (u'journal', '10.1103/PhysRevD.74.023508', [u'S. Weinberg'],
              '', 'Phys.Rev.', 'D74', '023508', '2006', '21', '', '', '', [], '', '', []),
+            (u'journal', '10.1088/0305-4470/35/5/312', [u'A. Romeo', u'A.A. Saharian'],
+             '', 'J.Phys.', 'A35', '1297', '2002', '22', '', '', '', [], '', '', []),
+            (u'book', '', [u'A.A. Saharian'], '', 
+             'The Generalized Abel-Plana Formula with Applications to Bessel Functions and Casimir Effect', 
+             '', '', '2008', '22', '', 
+             'Yerevan State University Publishing House', '', u'Yerevan,', '', '', []),
+            (u'report', '', [u'A. Romeo', u'A.A. Saharian'], 
+             '', '', '', '', '', '22', '', '', '', u'Report No ICTP/2007/082', '', '', [])
         ]
         for ref in self.aps.document.getElementsByTagName('ref'):
             for innerref in self.aps._get_reference(ref):
                 self.assertTrue(innerref in references)
-
     def test_article_type(self):
         """Check extracted article type."""
         self.assertEqual(self.aps._get_article_type(), 'research-article')

--- a/harvestingkit/tests/data/sample_aps_output.xml
+++ b/harvestingkit/tests/data/sample_aps_output.xml
@@ -543,4 +543,29 @@
     <subfield code="s">Phys.Rev.,D74,023508</subfield>
     <subfield code="d">journal</subfield>
   </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="a">10.1088/0305-4470/35/5/312</subfield>
+    <subfield code="h">A. Romeo</subfield>
+    <subfield code="h">A.A. Saharian</subfield>
+    <subfield code="y">2002</subfield>
+    <subfield code="o">22</subfield>
+    <subfield code="s">J.Phys.,A35,1297</subfield>
+    <subfield code="d">journal</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">A.A. Saharian</subfield>
+    <subfield code="y">2008</subfield>
+    <subfield code="m">Yerevan,</subfield>
+    <subfield code="p">Yerevan State University Publishing House</subfield>
+    <subfield code="o">22</subfield>
+    <subfield code="t">The Generalized Abel-Plana Formula with Applications to Bessel Functions and Casimir Effect</subfield>
+    <subfield code="d">book</subfield>
+  </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">A. Romeo</subfield>
+    <subfield code="h">A.A. Saharian</subfield>
+    <subfield code="m">Report No ICTP/2007/082</subfield>
+    <subfield code="o">22</subfield>
+    <subfield code="d">report</subfield>
+  </datafield>
 </record>

--- a/harvestingkit/tests/data/sample_aps_record.xml
+++ b/harvestingkit/tests/data/sample_aps_record.xml
@@ -340,6 +340,12 @@
         <mixed-citation id="c21a" publication-type="journal"><object-id>21a</object-id><person-group person-group-type="author"><string-name>S. Weinberg</string-name></person-group>, <source>Phys. Rev. D</source><volume>72</volume><page-range>043514</page-range> (<year>2005</year>); <pub-id pub-id-type="coden">PRVDAQ</pub-id><issn>1550-7998</issn><pub-id pub-id-type="doi" specific-use="suppress-display">10.1103/PhysRevD.72.043514</pub-id></mixed-citation>
         <mixed-citation id="c21b" publication-type="journal" specific-use="authorjournal"><object-id>21b</object-id><person-group person-group-type="author"><string-name>S. Weinberg</string-name></person-group><source>Phys. Rev. D</source><volume>74</volume>, <page-range>023508</page-range> (<year>2006</year>).<pub-id pub-id-type="coden">PRVDAQ</pub-id><issn>1550-7998</issn><pub-id pub-id-type="doi" specific-use="suppress-display">10.1103/PhysRevD.74.023508</pub-id></mixed-citation>
       </ref>
+      <ref id="c22">
+        <label>[22]</label>
+           <mixed-citation id="c22a" publication-type="journal"><object-id>22a</object-id><person-group person-group-type="author"><string-name>A. Romeo</string-name> and <string-name>A.A. Saharian</string-name></person-group>, <source>J. Phys. A</source> <volume>35</volume>, <page-range>1297</page-range> (<year>2002</year>); <pub-id pub-id-type="coden">JPHAC5</pub-id><issn>0305-4470</issn><pub-id pub-id-type="doi" specific-use="suppress-display">10.1088/0305-4470/35/5/312</pub-id></mixed-citation>
+            <mixed-citation id="c22b" publication-type="book"><object-id>22b</object-id><person-group person-group-type="author"><string-name>A.A. Saharian</string-name></person-group>, <source>The Generalized Abel-Plana Formula with Applications to Bessel Functions and Casimir Effect</source> (<publisher-name>Yerevan State University Publishing House</publisher-name>, Yerevan, <year>2008</year>); </mixed-citation>
+            <mixed-citation id="c22c" publication-type="report"><object-id>22c</object-id><person-group person-group-type="author"><string-name>A. Romeo</string-name> and <string-name>A.A. Saharian</string-name></person-group>, Report No. <pub-id pub-id-type="other"/>ICTP/2007/082.</mixed-citation>
+        </ref>
     </ref-list>
   </back>
 </article>


### PR DESCRIPTION
* Adds 'if *.hasChildNodes():' statements to avoid calling
  .firstChild.data on tags without childs.

* Adds an encording case to the test suite.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>