### PR TITLE
aps_package: reference parsing fix

### DIFF
--- a/harvestingkit/aps_package.py
+++ b/harvestingkit/aps_package.py
@@ -29,7 +29,8 @@ from harvestingkit.bibrecord import (
     record_xml_output,
 )
 from harvestingkit.minidom_utils import (get_value_in_tag,
-                                         xml_to_text)
+                                         xml_to_text,
+                                         get_all_text)
 from harvestingkit.jats_package import JatsPackage
 
 
@@ -56,7 +57,7 @@ class ApsPackage(JatsPackage):
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'other':
                     if tag.hasChildNodes():
-                        report_no = tag.firstChild.data
+                        report_no = get_all_text(tag)
             doi = ''
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'doi':
@@ -68,13 +69,13 @@ class ApsPackage(JatsPackage):
                 if author_group.getAttribute('person-group-type') == 'author':
                     for author in author_group.getElementsByTagName('string-name'):
                         if author.hasChildNodes():
-                            authors.append(author.firstChild.data)
+                            authors.append(get_all_text(author))
             editors = []
             for editor_group in person_groups:
                 if editor_group.getAttribute('person-group-type') == 'editor':
                     for editor in editor_group.getElementsByTagName('string-name'):
                         if editor.hasChildNodes():
-                            editors.append(editor.firstChild.data)
+                            editors.append(get_all_text(editor))
             journal = get_value_in_tag(innerref, 'source')
             journal, volume = fix_journal_name(journal, self.journal_mappings)
             volume += get_value_in_tag(innerref, 'volume')
@@ -89,7 +90,7 @@ class ApsPackage(JatsPackage):
             for tag in innerref.getElementsByTagName('pub-id'):
                 if tag.getAttribute('pub-id-type') == 'arxiv':
                     if tag.hasChildNodes():
-                        arxiv = tag.firstChild.data
+                        arxiv = get_all_text(tag)
             arxiv = format_arxiv_id(arxiv)
             publisher = get_value_in_tag(innerref, 'publisher-name')
             publisher_location = get_value_in_tag(innerref, 'publisher-loc')

--- a/harvestingkit/minidom_utils.py
+++ b/harvestingkit/minidom_utils.py
@@ -62,6 +62,17 @@ def get_value_in_tag(xml, tag, tag_to_remove=None):
         return ""
 
 
+def get_all_text(node):
+    """Recursively extract all text from node."""
+    if node.nodeType == node.TEXT_NODE:
+        return node.data
+    else:
+        text_string = ""
+        for child_node in node.childNodes:
+            text_string += get_all_text(child_node)
+        return text_string
+
+
 def get_attribute_in_tag(xml, tag, attr):
     tag_elements = xml.getElementsByTagName(tag)
     tag_attributes = []


### PR DESCRIPTION
* Fixes an issue with getting authors from reference nodes where
  sometimes a 'string-name' node would have nested tags.

* Adds a new utility to get all text from a certain node in minidom
  context.

Reported-by: Florian Schwennsen <schwenn@l00slschwennsen.desy.de>
Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>