### PR TITLE
elsevier_package: add handling of article-number in references

### DIFF
--- a/harvestingkit/elsevier_package.py
+++ b/harvestingkit/elsevier_package.py
@@ -660,6 +660,8 @@ class ElsevierPackage(object):
     def _get_ref(self, ref, label):
         doi = get_value_in_tag(ref, "ce:doi")
         page = get_value_in_tag(ref, "sb:first-page")
+        if not page:
+            page = get_value_in_tag(ref, "sb:article-number")
         issue = get_value_in_tag(ref, "sb:issue")
         title = get_value_in_tag(ref, "sb:maintitle")
         volume = get_value_in_tag(ref, "sb:volume-nr")

--- a/harvestingkit/tests/data/sample_consyn_output.xml
+++ b/harvestingkit/tests/data/sample_consyn_output.xml
@@ -177,4 +177,11 @@
     <subfield code="m">D. Kastor, E. Martinec and Z. Qiu, E. Fermi Institute preprint EFI-87-58.</subfield>
     <subfield code="o">14</subfield>
   </datafield>
+  <datafield tag="999" ind1="C" ind2="5">
+    <subfield code="h">Adeva, B.</subfield>
+    <subfield code="v">58</subfield>
+    <subfield code="y">1998</subfield>
+    <subfield code="o">15</subfield>
+    <subfield code="s">Phys.Rev.,D58,112001</subfield>
+  </datafield>
 </record>

--- a/harvestingkit/tests/data/sample_consyn_record.xml
+++ b/harvestingkit/tests/data/sample_consyn_record.xml
@@ -487,6 +487,32 @@
 	 				<ce:textref>G. Moore and N. Seiberg, unpublished.</ce:textref>
 	 			</ce:other-ref>
 	 		</ce:bib-reference>
+			<ce:bib-reference id="bib15">
+                                <ce:label>[15]</ce:label>
+				<sb:reference id="bib33s1">
+				  <sb:contribution langtype="en">
+				    <sb:authors>
+				      <sb:author>
+					<ce:given-name>B.</ce:given-name>
+					<ce:surname>Adeva</ce:surname>
+				      </sb:author>
+				      <sb:et-al/>
+				    </sb:authors>
+				  </sb:contribution>
+				  <sb:host>
+				    <sb:issue>
+				      <sb:series>
+					<sb:title>
+					  <sb:maintitle>Phys. Rev. D</sb:maintitle>
+					</sb:title>
+					<sb:volume-nr>58</sb:volume-nr>
+				      </sb:series>
+				      <sb:date>1998</sb:date>
+				    </sb:issue>
+				    <sb:article-number>112001</sb:article-number>
+				  </sb:host>
+				</sb:reference>
+			</ce:bib-reference>
 	 	</ce:bibliography-sec>
 	 </ce:bibliography>
 	</ja:tail>

--- a/harvestingkit/tests/elsevier_package_tests.py
+++ b/harvestingkit/tests/elsevier_package_tests.py
@@ -183,7 +183,8 @@ class ElsevierPackageTests(unittest.TestCase):
                       ('[11]', ['Dehn, M.'], '', 'Acta Math. 69 1938', '135', '', '69', '1938', [], None, True, '', 'Acta Math.', '', [], ''),
                       ('[12]', [], '', '', '', '', '', '', 'D. Friedan and S. Shenker, unpublished.', None, [], '', '', '', [], ''),
                       ('[13]', [], '', '', '', '', '', '', 'J. Harvey, G. Moore, and C. Vafa, Nucl. Phys. B, to be published', None, [], '', '', '', [], ''),
-                      ('[14]', [], '', '', '', '', '', '', 'D. Kastor, E. Martinec and Z. Qiu, E. Fermi Institute preprint EFI-87-58.', None, [], '', '', '', [], '')]
+                      ('[14]', [], '', '', '', '', '', '', 'D. Kastor, E. Martinec and Z. Qiu, E. Fermi Institute preprint EFI-87-58.', None, [], '', '', '', [], ''),
+                      ('[15]', ['Adeva, B.'], '', 'Phys. Rev. D 58 1998', '112001', '', '58', '1998', [], None, True, '', 'Phys. Rev. D', '', [], '')]
         for ref in self.els.get_references(self.document):
             self.assertTrue(ref in references)
 
@@ -201,7 +202,6 @@ class ElsevierPackageTests(unittest.TestCase):
         with open(marc_file) as marc:
             result = marc.read()
         self.assertEqual(xml.strip(), result.strip())
-
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(ElsevierPackageTests)


### PR DESCRIPTION
* If there is no sb:first-page in a reference, get_ref now looks for
  sb:article-number.

* elsevier_package_tests is modified accordingly.

Signed-off-by: fschwenn <florian.schwennsen@desy.de>