### PR TITLE
bibrecord: field addition fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,33 @@
 *.pyc
 *.kate-swp
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec

--- a/harvestingkit/bibrecord.py
+++ b/harvestingkit/bibrecord.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Harvesting Kit.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Harvesting Kit is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -548,6 +548,7 @@ def record_add_field(rec, tag, ind1=' ', ind2=' ', controlfield_value='',
                 immediate_lower_tag = '000'
                 for rec_tag in rec:
                     if (tag not in ('FMT', 'FFT', 'BDR', 'BDM') and
+                            rec[rec_tag] and
                             immediate_lower_tag < rec_tag < tag):
                         immediate_lower_tag = rec_tag
 


### PR DESCRIPTION
* Fixes determining the global position when inserting a new tag in an order manner, and the previous tag is empty and therefore doesn't have a global position.