### PR TITLE
inspire_cds_package: skip duplicate DOIs

### DIFF
--- a/harvestingkit/inspire_cds_package/from_inspire.py
+++ b/harvestingkit/inspire_cds_package/from_inspire.py
@@ -192,6 +192,7 @@ class Inspire2CDS(MARCXMLConversion):
         self.update_notes()
         self.update_experiments()
         self.update_isbn()
+        self.update_dois()
         self.update_links_and_ffts()
         self.update_date()
         self.update_date_year()
@@ -441,6 +442,19 @@ class Inspire2CDS(MARCXMLConversion):
             for idx, (key, value) in enumerate(field[0]):
                 if key == 'a':
                     field[0][idx] = ('a', value.replace("-", "").strip())
+
+    def update_dois(self):
+        """Remove duplicate BibMatch DOIs."""
+        dois = record_get_field_instances(self.record, '024', ind1="7")
+        all_dois = {}
+        for field in dois:
+            subs = field_get_subfield_instances(field)
+            subs_dict = dict(subs)
+            if subs_dict.get('a'):
+                if subs_dict['a'] in all_dois:
+                    record_delete_field(self.record, tag='024', ind1='7', field_position_global=field[4])
+                    continue
+                all_dois[subs_dict['a']] = field
 
     def update_journals(self):
         """773 journal translations."""

--- a/harvestingkit/tests/data/sample_inspire_oai.xml
+++ b/harvestingkit/tests/data/sample_inspire_oai.xml
@@ -13,6 +13,11 @@
     <marc:subfield code="2">DOI</marc:subfield>
     <marc:subfield code="a">10.1016/j.nima.2014.09.061</marc:subfield>
   </marc:datafield>
+  <marc:datafield tag="024" ind1="7" ind2=" ">
+    <marc:subfield code="2">DOI</marc:subfield>
+    <marc:subfield code="a">10.1016/j.nima.2014.09.061</marc:subfield>
+    <marc:subfield code="9">bibmatch</marc:subfield>
+  </marc:datafield>
   <marc:datafield tag="035" ind1=" " ind2=" ">
     <marc:subfield code="a">Sahin:2014haa</marc:subfield>
     <marc:subfield code="9">INSPIRETeX</marc:subfield>

--- a/harvestingkit/tests/inspire_cds_package_tests.py
+++ b/harvestingkit/tests/inspire_cds_package_tests.py
@@ -328,6 +328,18 @@ class TestINSPIRE2CDS(unittest.TestCase):
             ["9785949900109"]
         )
 
+    def test_duplicate_dois(self):
+        """Test for correct removal of duplicate DOIs."""
+        from harvestingkit.bibrecord import record_get_field_values
+
+        self.assertEqual(
+            record_get_field_values(self.converted_record,
+                                    tag="024",
+                                    ind1="7",
+                                    code="a"),
+            ["10.1016/j.nima.2014.09.061"]
+        )
+
     def test_fft(self):
         """Test for existence of FFT on PDF URL."""
         from harvestingkit.bibrecord import record_get_field_values

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="HarvestingKit",
-    version="0.6.12",
+    version="0.6.13",
     packages=find_packages(),
     package_data={
         '': ['data/*.xml'],


### PR DESCRIPTION
* INSPIRE has sometimes duplicate DOIs fields in MARCXML that differ
  by an additional $9bibmatch subfield. This is not valid on CDS
  side, so those duplicates are now skipped in Inspire2CDS.
  (Closes RQF0856063)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>