### PR TITLE
542 fix

### DIFF
--- a/harvestingkit/inspire_cds_package/from_inspire.py
+++ b/harvestingkit/inspire_cds_package/from_inspire.py
@@ -443,17 +443,17 @@ class Inspire2CDS(MARCXMLConversion):
 
     def update_542(self):
         """Change 542__e -> 542__3 and 542__e:Article to 542__3:publication."""
-        for field in record_get_field_instances(self.record, '542'):
+        fields = record_get_field_instances(self.record, '542')
+        for field_idx, field in enumerate(fields):
             subs = field_get_subfield_instances(field)
-            for idx, (key, value) in enumerate(field[0]):
+            for idx, (key, value) in enumerate(subs):
                 if key != 'e':
                     continue
-                # delete '__e'
-                del field[0][idx]
                 # change 'article' -> 'publication'
                 v = 'publication' if value.strip().lower() == 'article' else value
-                # add '__3'
-                record_add_field(self.record, "542", subfields=[("3", v)])
+
+                # update '__e'
+                field[0][idx] = ("3", v)
 
     def update_isbn(self):
         """Remove dashes from ISBN."""

--- a/harvestingkit/inspire_cds_package/from_inspire.py
+++ b/harvestingkit/inspire_cds_package/from_inspire.py
@@ -444,7 +444,7 @@ class Inspire2CDS(MARCXMLConversion):
     def update_542(self):
         """Change 542__e -> 542__3 and 542__e:Article to 542__3:publication."""
         fields = record_get_field_instances(self.record, '542')
-        for field_idx, field in enumerate(fields):
+        for field in fields:
             subs = field_get_subfield_instances(field)
             for idx, (key, value) in enumerate(subs):
                 if key != 'e':

--- a/harvestingkit/tests/inspire_cds_package_tests.py
+++ b/harvestingkit/tests/inspire_cds_package_tests.py
@@ -1012,15 +1012,24 @@ class TestINSPIRE2CDSGeneric(unittest.TestCase):
 
     def test_article_to_publication(self):
         """Test 542__e -> 542__3 Article is converted to Publication."""
-        from harvestingkit.bibrecord import record_get_field_values
+        from harvestingkit.bibrecord import field_get_subfield_instances,\
+            record_get_field_values, record_get_field_instances
         from harvestingkit.inspire_cds_package.from_inspire import Inspire2CDS
 
         xml = """
         <collection>
             <record>
                 <datafield tag="542" ind1=" " ind2=" ">
+                    <subfield code="g">Another Field</subfield>
+                    <subfield code="e">Not Article</subfield>
+                    <subfield code="a">Another Field</subfield>
+                </datafield>
+                <datafield tag="542" ind1=" " ind2=" ">
                     <subfield code="a">Another Field</subfield>
                     <subfield code="e">Article</subfield>
+                </datafield>
+                <datafield tag="542" ind1=" " ind2=" ">
+                    <subfield code="a">Only `a` subfield</subfield>
                 </datafield>
             </record>
             <record>
@@ -1033,14 +1042,28 @@ class TestINSPIRE2CDSGeneric(unittest.TestCase):
         rec1, rec2 = Inspire2CDS.from_source(xml)
 
         converted_rec1 = rec1.get_record()
-        rec1_3_value = record_get_field_values(converted_rec1, tag="542", code="3")
-        self.assertEqual(rec1_3_value, ["publication"])
-        rec1_a_value = record_get_field_values(converted_rec1, tag="542", code="a")
-        self.assertEqual(rec1_a_value, ["Another Field"])
+
+        rec1_542_fields = record_get_field_instances(converted_rec1, '542')
+        rec1_542_0_subs = field_get_subfield_instances(rec1_542_fields[0])
+        self.assertEqual(
+            rec1_542_0_subs,
+            [('g', 'Another Field'), ('3', 'Not Article'), ('a', 'Another Field')])
+
+        rec1_542_1_subs = field_get_subfield_instances(rec1_542_fields[1])
+        self.assertEqual(
+            rec1_542_1_subs, [('a', 'Another Field'), ('3', 'publication')])
+
+        rec1_542_2_subs = field_get_subfield_instances(rec1_542_fields[2])
+        self.assertEqual(
+            rec1_542_2_subs, [('a', 'Only `a` subfield')])
 
         converted_rec2 = rec2.get_record()
-        rec2_value = record_get_field_values(converted_rec2, tag="542", code="3")
-        self.assertEqual(rec2_value, ["AnotherValue"])
+
+        rec2_542_fields = record_get_field_instances(converted_rec2, '542')
+        rec2_542_0_subs = field_get_subfield_instances(rec2_542_fields[0])
+        self.assertEqual(
+            rec2_542_0_subs, [('3', 'AnotherValue')])
+
 
     def test_article_773(self):
         """Test if tag 773 has c,p,v,y then doc_type is ARTICLE."""

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="HarvestingKit",
-    version="0.6.19",
+    version="0.6.20",
     packages=find_packages(),
     package_data={
         '': ['data/*.xml'],


### PR DESCRIPTION
Fixes `542__e` -> `542__3` conversion. At the moment when the field was matched a new `542` tag was added instead of updating the existing one.